### PR TITLE
Update umc-mapcommands.sp

### DIFF
--- a/addons/sourcemod/scripting/umc-mapcommands.sp
+++ b/addons/sourcemod/scripting/umc-mapcommands.sp
@@ -87,6 +87,26 @@ public OnConfigsExecuted()
 //Execute pre-commands when map ends
 public OnMapEnd()
 {
+    if (strlen(group_command) == 0 || strlen(map_command) == 0)
+    {
+        new Handle:kv = GetKvFromFile("umc_mapcycle.txt", "umc_mapcycle");
+        decl String:CurrentMapGroup[ 64 ], String:CurrentMap[ 64 ];
+        
+        GetCurrentMap(CurrentMap, sizeof(CurrentMap));
+        KvFindGroupOfMap(kv, CurrentMap, CurrentMapGroup, sizeof(CurrentMapGroup));
+        
+        if (KvJumpToKey(kv, CurrentMapGroup))
+        {    
+            if (strlen( group_command ) == 0)
+                KvGetString(kv, COMMAND_KEY, group_command, sizeof(group_command), "");
+        
+            if (KvJumpToKey(kv, CurrentMap) && strlen( map_command ) == 0)
+                KvGetString(kv, COMMAND_KEY, map_command, sizeof(map_command), "");
+        }
+        
+        CloseHandle( kv );
+    }
+    
     DEBUG_MESSAGE("Executing MapCommands OnMapEnd")
     if (strlen(group_precommand) > 0)
     {


### PR DESCRIPTION
Add look up for "command" in map group and map, always when map start.
In previous version, "command" wasn't executed when map was changed other way then UMC set map command (eg. sm_map or just server start).

But this might be a little messy and buggy solution..

1) I don't know how get root keyvalue of map cycle (sometimes umc_mapcycle and sometimes umc_rotation)

2) I am not sure how does my solution work if one map is placed in two different groups..
