### PR TITLE
Moved ForceChangeMap as native in umc-core.sp

### DIFF
--- a/addons/sourcemod/scripting/include/umc-core.inc
+++ b/addons/sourcemod/scripting/include/umc-core.inc
@@ -46,6 +46,7 @@ public __pl_umccore_SetNTVOptional()
     MarkNativeAsOptional("UMC_VoteManagerClientVoted");
     MarkNativeAsOptional("UMC_FormatDisplayString");
     MarkNativeAsOptional("UMC_IsNewVoteAllowed");
+    MarkNativeAsOptional("UMC_ForceChangeMap");
 }
 
 #define INVALID_GROUP ""
@@ -359,6 +360,15 @@ forward UMC_OnNextmapSet(Handle:kv, const String:map[], const String:group[],
  */
 forward UMC_RequestReloadMapcycle();
 
+/**
+ * Called immediately after UMC ForceChangeMap Native was called
+ *
+ * @param time    The time before the map change
+ * 
+ * @noreturn
+ */
+forward UMC_OnForceMapChange(const Float:time);
+
 
 /**
  * Retrieves the name of the current map group.
@@ -519,3 +529,8 @@ native UMC_FormatDisplayString(String:display[], maxlen, Handle:mapcycle, const 
  * @return  True if we can start a new vote, false otherwise.
  */
 native bool:UMC_IsNewVoteAllowed(const String:id[]="core");
+
+/**
+ * Changes the map after the specified time period.
+ */
+native UMC_ForceChangeMap(const String:map[], Float:time, const String:reason[]="");

--- a/addons/sourcemod/scripting/include/umc_utils.inc
+++ b/addons/sourcemod/scripting/include/umc_utils.inc
@@ -250,7 +250,7 @@ enum CustomHudFallbackType {
     HudFallback_Chat,
     HudFallback_Hint,
     HudFallback_Center,
-	HudFallback_None
+    HudFallback_None
 }
 
 //Color Arrays for colors in warning messages.
@@ -425,7 +425,7 @@ public Action:Timer_CenterAd(Handle:timer, Handle:pack)
 
 //
 // stock TF2_SendCustomHudMessage(client, const String:icon[], team=-1, CustomHudFallbackType:fallback,
-// 							   const String:format[], any:...)
+//                                const String:format[], any:...)
 // {
 //     decl String:message[256];
 //     VFormat(message, sizeof(message), format, 6);
@@ -442,7 +442,7 @@ public Action:Timer_CenterAd(Handle:timer, Handle:pack)
 
 // //
 // stock TF2_SendCustomHudMessageAll(const String:icon[], team=-1, CustomHudFallbackType:fallback,
-// 								  const String:format[], any:...)
+//                                   const String:format[], any:...)
 // {
 //     decl String:message[256];
 //     VFormat(message, sizeof(message), format, 5);
@@ -465,7 +465,7 @@ public Action:Timer_CenterAd(Handle:timer, Handle:pack)
 
 // //
 // public MinModeCheckFinished(QueryCookie:cookie, uid, ConVarQueryResult:result, const String:cvarName[],
-// 							const String:cvarValue[], any:pack)
+//                             const String:cvarValue[], any:pack)
 // {
 //     ResetPack(pack);
 //     new client = GetClientOfUserId(ReadPackCell(pack));
@@ -634,43 +634,8 @@ stock ForceChangeInFive(const String:map[], const String:reason[]="")
     PrintToChatAll("\x03[UMC]\x01 %t", "Map Change in 5");
     
     //Setup the change.
-    ForceChangeMap(map, 5.0, reason);
+    UMC_ForceChangeMap(map, 5.0, reason);
 }
-
-
-//Changes the map after the specified time period.
-stock ForceChangeMap(const String:map[], Float:time, const String:reason[]="")
-{
-    LogUMCMessage("%s: Changing map to '%s' in %.f seconds.", reason, map, time);
-
-    //Setup the timer.
-    new Handle:pack;
-    CreateDataTimer(
-        time,
-        Handle_MapChangeTimer,
-        pack,
-        TIMER_FLAG_NO_MAPCHANGE
-    );
-    WritePackString(pack, map);
-    WritePackString(pack, reason);
-}
-
-
-//Called after the mapchange timer is completed.
-public Action:Handle_MapChangeTimer(Handle:timer, Handle:pack)
-{
-    //Get map from the timer's pack.
-    decl String:map[MAP_LENGTH], String:reason[255];
-    ResetPack(pack);
-    ReadPackString(pack, map, sizeof(map));
-    ReadPackString(pack, reason, sizeof(reason));
-    
-    DEBUG_MESSAGE("Changing map to %s: %s", map, reason)
-    
-    //Change the map.
-    ForceChangeLevel(map, reason);
-}
-
 
 //Determines if the current server time is between the given min and max.
 stock bool:IsTimeBetween(min, max)


### PR DESCRIPTION
I moved the ForceChangeMap function to a native in umc-core.sp for calling a forward when umc want to change a map.

I'm using it for an other plugin and I think it's a good improvement.