### PR TITLE
Don't print version to everyone

### DIFF
--- a/addons/sourcemod/scripting/umc-core.sp
+++ b/addons/sourcemod/scripting/umc-core.sp
@@ -965,7 +965,7 @@ public Action:OnPlayerChat(client, const String:command[], argc)
     
     if (StrEqual(text, "umc", false) || StrEqual(text, "!umc", false)
         || StrEqual(text, "/umc", false))
-        PrintToChatAll("[SM] Ultimate Mapchooser v%s by Steell", PL_VERSION);
+        PrintToChat(client, "[SM] Ultimate Mapchooser v%s by Steell", PL_VERSION);
     
     return Plugin_Continue;
 }


### PR DESCRIPTION
The say command for the UMC version can be spammed in console to spam the version text to all players. It should only print the version to the player who initiated the command.